### PR TITLE
Fix promise implementation used by 'mz/fs' to bluebird.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function listDir (path, originalPath) {
   // promises for sub listDir calls
   var dirs = [];
 
-  return fs.readdir(path)
+  return Promise.resolve(fs.readdir(path))
     // include only files
     .filter(function (item) {
       var absolutePath = join(path, item);


### PR DESCRIPTION
This fixes the following problem:

```
> make test

  list-dir
    ✓ sync
    1) promises


  1 passing (22ms)
  1 failing

  1) list-dir promises:
     TypeError: fs.readdir(...).filter is not a function
      at listDir (index.js:39:6)
      at Context.<anonymous> (test/test.js:31:5)
```

`mz/fs` uses `any-promise`, which in turn uses native promises when available. Native promises don't have a filter function. When we have set the desired promise implementation manually, all tests pass.
